### PR TITLE
Ques 10 : JaCoCo, Codecov 적용

### DIFF
--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -10,17 +10,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # 코드 체크아웃
       - uses: actions/checkout@v4
 
+      # gradlew 실행 권한 부여
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      # JDK 설정
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
 
+      # Gradle 빌드 및 테스트 실행
       - name: Build and run tests with Gradle
         run: ./gradlew clean build jacocoTestReport
 
+      # Codecov로 커버리지 업로드
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -1,0 +1,30 @@
+name: CODECOV_CI
+
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Build and run tests with Gradle
+        run: ./gradlew clean build jacocoTestReport
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: build/reports/jacoco/test/jacocoTestReport.xml
+          flags: unittests
+          fail_ci_if_error: true

--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # 코드 체크아웃
       - uses: actions/checkout@v4
 
       # gradlew 실행 권한 부여
@@ -24,11 +23,13 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      # Gradle 빌드 및 테스트 실행
+      # Gradle 빌드 및 테스트 실행 (테스트 프로파일 적용)
       - name: Build and run tests with Gradle
         run: ./gradlew clean build jacocoTestReport
+        env:
+          SPRING_PROFILES_ACTIVE: test
 
-      # Codecov로 커버리지 업로드
+      # Codecov 업로드
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ jacoco {
 test {
     useJUnitPlatform() // JUnit5 사용하는 경우
     finalizedBy jacocoTestReport // 테스트 후 리포트 생성
+    systemProperty "spring.profiles.active", "test" // CI 환경에서 테스트용 프로파일 적용
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -45,12 +45,12 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'COVEREDRATIO'
-                minimum = 0.80 // 라인 커버리지 80% 이상
+                minimum = 0.60 // 라인 커버리지 60% 이상
             }
             limit {
                 counter = 'BRANCH'
                 value = 'COVEREDRATIO'
-                minimum = 0.60 // 브랜치 커버리지 60% 이상
+                minimum = 0.05 // 브랜치 커버리지 5% 이상
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.4'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'com.project'
@@ -13,11 +14,49 @@ java {
     }
 }
 
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+test {
+    useJUnitPlatform() // JUnit5 사용하는 경우
+    finalizedBy jacocoTestReport // 테스트 후 리포트 생성
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
 }
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true   // Codecov 업로드용
+        html.required = true  // 로컬에서 확인용
+        csv.required = false
+    }
+}
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            // 전체 기준
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80 // 라인 커버리지 80% 이상
+            }
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.60 // 브랜치 커버리지 60% 이상
+            }
+        }
+    }
+}
+
+// check task에 커버리지 검증 연결
+check.dependsOn jacocoTestCoverageVerification
 
 repositories {
     mavenCentral()

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,3 +11,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  data:
+    redis:
+      port: 0


### PR DESCRIPTION
## 변경 유형
- [x] CI/CD
- [x] Build/테스트 설정

## 배경
- Gradle 프로젝트에 JaCoCo를 적용하여 테스트 커버리지 측정
- GitHub Actions CI에서 Codecov로 커버리지 리포트 업로드

## 구현 내용
- Gradle build.gradle
  - JaCoCo 플러그인 추가
  - 라인 커버리지 60%, 브랜치 커버리지 5% 이상 빌드 실패 조건 설정
  - jacocoTestReport task로 HTML, XML 리포트 생성
- GitHub Actions
  - 테스트 후 jacocoTestReport.xml을 Codecov로 업로드
  - PR 단위 커버리지 변화 확인 가능

## 검증 방법
- `./gradlew check` 실행 시 커버리지 기준 미달이면 빌드 실패 확인
- Codecov PR 코멘트에서 커버리지 변화 확인
- build/reports/jacoco/test/html/index.html 확인 시 패키지/클래스 단위 커버리지 확인

## 목적 및 기대 효과
- 테스트 코드 품질 관리 자동화
- CI에서 커버리지 기준 미달 시 빌드 실패로 품질 게이트 적용
- PR 리뷰에서 커버리지 영향 확인 가능
- 팀 전체 코드 품질 관리 강화 및 테스트 부족 영역 빠른 식별
